### PR TITLE
TEST: Add 3.12-dev [ci]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -534,6 +534,7 @@ jobs:
           PIP_CACHE_DIR=$PIP_CACHE pip install -U "pip>=21.3.1" setuptools wheel
           PIP_CACHE_DIR=$PIP_CACHE pip install -r requirements_all.txt
           PIP_CACHE_DIR=$PIP_CACHE pip install -r requirements_test.txt
+          pip install --no-deps --force-reinstall git+https://github.com/pytest-dev/pytest.git@b73b4c464c6fa54f55a1c6ed8eaceb5529a161bb
           pip install -e . --config-settings editable_mode=compat
       - name: Save pip wheel cache
         if: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,13 +33,13 @@ on:
         type: boolean
 
 env:
-  CACHE_VERSION: 5
+  CACHE_VERSION: 5-c1
   PIP_CACHE_VERSION: 4
   MYPY_CACHE_VERSION: 5
   BLACK_CACHE_VERSION: 1
   HA_SHORT_VERSION: "2023.11"
   DEFAULT_PYTHON: "3.11"
-  ALL_PYTHON_VERSIONS: "['3.11']"
+  ALL_PYTHON_VERSIONS: "['3.11', '3.12']"
   # 10.3 is the oldest supported version
   # - 10.3.32 is the version currently shipped with Synology (as of 17 Feb 2022)
   # 10.6 is the current long-term-support
@@ -61,9 +61,9 @@ env:
   PYTHONASYNCIODEBUG: 1
   HASS_CI: 1
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+#   cancel-in-progress: true
 
 jobs:
   info:
@@ -472,8 +472,9 @@ jobs:
     name: Prepare dependencies
     runs-on: ubuntu-22.04
     needs: info
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
+      fail-fast: false
       matrix:
         python-version: ${{ fromJSON(needs.info.outputs.python_versions) }}
     steps:
@@ -501,7 +502,7 @@ jobs:
             needs.info.outputs.python_cache_key }}
       - name: Restore pip wheel cache
         if: steps.cache-venv.outputs.cache-hit != 'true'
-        uses: actions/cache@v3.3.2
+        uses: actions/cache/restore@v3.3.2
         with:
           path: ${{ env.PIP_CACHE }}
           key: >-
@@ -534,6 +535,16 @@ jobs:
           PIP_CACHE_DIR=$PIP_CACHE pip install -r requirements_all.txt
           PIP_CACHE_DIR=$PIP_CACHE pip install -r requirements_test.txt
           pip install -e . --config-settings editable_mode=compat
+      - name: Save pip wheel cache
+        if: |
+          steps.cache-venv.outputs.cache-hit != 'true'
+          && (success() || failure())
+        uses: actions/cache/save@v3.3.2
+        with:
+          path: ${{ env.PIP_CACHE }}
+          key: >-
+            ${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{
+            steps.generate-pip-key.outputs.key }}
 
   hassfest:
     name: Check hassfest
@@ -717,16 +728,11 @@ jobs:
     needs:
       - info
       - base
-      - gen-requirements-all
-      - hassfest
-      - lint-other
-      - lint-ruff
-      - mypy
     strategy:
       fail-fast: false
       matrix:
         group: ${{ fromJson(needs.info.outputs.test_groups) }}
-        python-version: ${{ fromJson(needs.info.outputs.python_versions) }}
+        python-version: ["3.12"]
     name: >-
       Run tests Python ${{ matrix.python-version }} (${{ matrix.group }})
     steps:
@@ -860,7 +866,8 @@ jobs:
           MYSQL_ROOT_PASSWORD: password
         options: --health-cmd="mysqladmin ping -uroot -ppassword" --health-interval=5s --health-timeout=2s --health-retries=3
     if: |
-      (github.event_name != 'push' || github.event.repository.full_name == 'home-assistant/core')
+      false
+      && (github.event_name != 'push' || github.event.repository.full_name == 'home-assistant/core')
       && github.event.inputs.lint-only != 'true'
       && github.event.inputs.pylint-only != 'true'
       && github.event.inputs.mypy-only != 'true'
@@ -984,7 +991,8 @@ jobs:
           POSTGRES_PASSWORD: password
         options: --health-cmd="pg_isready -hlocalhost -Upostgres" --health-interval=5s --health-timeout=2s --health-retries=3
     if: |
-      (github.event_name != 'push' || github.event.repository.full_name == 'home-assistant/core')
+      false
+      && (github.event_name != 'push' || github.event.repository.full_name == 'home-assistant/core')
       && github.event.inputs.lint-only != 'true'
       && github.event.inputs.pylint-only != 'true'
       && github.event.inputs.mypy-only != 'true'

--- a/homeassistant/components/apache_kafka/manifest.json
+++ b/homeassistant/components/apache_kafka/manifest.json
@@ -2,6 +2,7 @@
   "domain": "apache_kafka",
   "name": "Apache Kafka",
   "codeowners": ["@bachya"],
+  "disabled": "Dependencies does not support Python 3.12",
   "documentation": "https://www.home-assistant.io/integrations/apache_kafka",
   "iot_class": "local_push",
   "loggers": ["aiokafka", "kafka_python"],

--- a/homeassistant/components/brother/manifest.json
+++ b/homeassistant/components/brother/manifest.json
@@ -3,6 +3,7 @@
   "name": "Brother Printer",
   "codeowners": ["@bieniu"],
   "config_flow": true,
+  "disabled": "Dependencies does not support Python 3.12",
   "documentation": "https://www.home-assistant.io/integrations/brother",
   "integration_type": "device",
   "iot_class": "local_polling",

--- a/homeassistant/components/cisco_webex_teams/manifest.json
+++ b/homeassistant/components/cisco_webex_teams/manifest.json
@@ -2,6 +2,7 @@
   "domain": "cisco_webex_teams",
   "name": "Cisco Webex Teams",
   "codeowners": ["@fbradyirl"],
+  "disabled": "Dependencies does not support Python 3.12",
   "documentation": "https://www.home-assistant.io/integrations/cisco_webex_teams",
   "iot_class": "cloud_push",
   "loggers": ["webexteamssdk"],

--- a/homeassistant/components/metoffice/manifest.json
+++ b/homeassistant/components/metoffice/manifest.json
@@ -3,6 +3,7 @@
   "name": "Met Office",
   "codeowners": ["@MrHarcombe", "@avee87"],
   "config_flow": true,
+  "disabled": "Dependencies does not support Python 3.12",
   "documentation": "https://www.home-assistant.io/integrations/metoffice",
   "iot_class": "cloud_polling",
   "loggers": ["datapoint"],

--- a/homeassistant/components/profiler/manifest.json
+++ b/homeassistant/components/profiler/manifest.json
@@ -3,6 +3,7 @@
   "name": "Profiler",
   "codeowners": ["@bdraco"],
   "config_flow": true,
+  "disabled": "Dependencies does not support Python 3.12",
   "documentation": "https://www.home-assistant.io/integrations/profiler",
   "quality_scale": "internal",
   "requirements": ["pyprof2calltree==1.4.5", "guppy3==3.1.3", "objgraph==3.5.0"]

--- a/homeassistant/components/python_script/manifest.json
+++ b/homeassistant/components/python_script/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/python_script",
   "loggers": ["RestrictedPython"],
   "quality_scale": "internal",
-  "requirements": ["RestrictedPython==6.2"]
+  "requirements": ["RestrictedPython==7.0a1.dev0"]
 }

--- a/homeassistant/components/snmp/manifest.json
+++ b/homeassistant/components/snmp/manifest.json
@@ -2,6 +2,7 @@
   "domain": "snmp",
   "name": "SNMP",
   "codeowners": [],
+  "disabled": "Dependencies does not support Python 3.12",
   "documentation": "https://www.home-assistant.io/integrations/snmp",
   "iot_class": "local_polling",
   "loggers": ["pyasn1", "pysmi", "pysnmp"],

--- a/homeassistant/components/vulcan/manifest.json
+++ b/homeassistant/components/vulcan/manifest.json
@@ -3,6 +3,7 @@
   "name": "Uonet+ Vulcan",
   "codeowners": ["@Antoni-Czaplicki"],
   "config_flow": true,
+  "disabled": "Dependencies does not support Python 3.12",
   "documentation": "https://www.home-assistant.io/integrations/vulcan",
   "iot_class": "cloud_polling",
   "quality_scale": "silver",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Home Automation",
 ]
 requires-python = ">=3.11.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,8 @@ disable = [
     "consider-using-f-string",
     "consider-using-namedtuple-or-dataclass",
     "consider-using-assignment-expr",
+    "deprecated-module",
+    "no-name-in-module",
 
     # Handled by ruff
     # Ref: <https://github.com/astral-sh/ruff/issues/970>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -423,8 +423,6 @@ log_format = "%(asctime)s.%(msecs)03d %(levelname)-8s %(threadName)s %(name)s:%(
 log_date_format = "%Y-%m-%d %H:%M:%S"
 asyncio_mode = "auto"
 filterwarnings = [
-    "error::sqlalchemy.exc.SAWarning",
-
     # -- HomeAssistant - aiohttp
     # Overwrite web.Application to pass a custom default argument to _make_request
     "ignore:Inheritance class HomeAssistantApplication from web.Application is discouraged:DeprecationWarning",
@@ -442,6 +440,8 @@ filterwarnings = [
     "ignore:ssl.TLSVersion.TLSv1 is deprecated:DeprecationWarning:elkm1_lib.util",
     # https://github.com/michaeldavie/env_canada/blob/v0.5.37/env_canada/ec_cache.py
     "ignore:Inheritance class CacheClientSession from ClientSession is discouraged:DeprecationWarning:env_canada.ec_cache",
+    # https://github.com/allenporter/ical/pull/215 - v5.0.0
+    "ignore:datetime.*utcnow\\(\\) is deprecated and scheduled for removal:DeprecationWarning:ical.util",
     # https://github.com/bachya/regenmaschine/blob/2023.08.0/regenmaschine/client.py#L51
     "ignore:ssl.TLSVersion.SSLv3 is deprecated:DeprecationWarning:regenmaschine.client",
 
@@ -454,6 +454,13 @@ filterwarnings = [
     # -- tracked upstream / open PRs
     # https://github.com/caronc/apprise/issues/659 - v1.4.5
     "ignore:Use setlocale\\(\\), getencoding\\(\\) and getlocale\\(\\) instead:DeprecationWarning:apprise.AppriseLocal",
+    # https://github.com/kiorky/croniter/issues/49 - v1.4.1
+    "ignore:datetime.*utcfromtimestamp\\(\\) is deprecated and scheduled for removal:DeprecationWarning:croniter.croniter",
+    # https://github.com/spulec/freezegun/issues/508 - v1.2.2
+    # https://github.com/spulec/freezegun/pull/511
+    "ignore:datetime.*utcnow\\(\\) is deprecated and scheduled for removal:DeprecationWarning:freezegun.api",
+    # https://github.com/influxdata/influxdb-client-python/issues/603 - v1.37.0
+    "ignore:datetime.*utcfromtimestamp\\(\\) is deprecated and scheduled for removal:DeprecationWarning:influxdb_client.client.write.point",
     # https://github.com/beetbox/mediafile/issues/67 - v0.12.0
     "ignore:'imghdr' is deprecated and slated for removal in Python 3.13:DeprecationWarning:mediafile",
     # https://github.com/eclipse/paho.mqtt.python/issues/653 - v1.6.1
@@ -461,6 +468,8 @@ filterwarnings = [
     "ignore:ssl.PROTOCOL_TLS is deprecated:DeprecationWarning:paho.mqtt.client",
     # https://github.com/PythonCharmers/python-future/issues/488 - v0.18.3
     "ignore:the imp module is deprecated in favour of importlib and slated for removal in Python 3.12:DeprecationWarning:future.standard_library",
+    # https://github.com/frenck/python-toonapi/pull/9 - v0.2.1 - 2021-09-23
+    "ignore:datetime.*utcnow\\(\\) is deprecated and scheduled for removal:DeprecationWarning:toonapi.models",
     # https://github.com/foxel/python_ndms2_client/issues/6 - v0.1.2
     "ignore:'telnetlib' is deprecated and slated for removal in Python 3.13:DeprecationWarning:ndms2_client.connection",
     # https://github.com/pytest-dev/pytest-cov/issues/557 - v4.1.0
@@ -468,14 +477,37 @@ filterwarnings = [
     "ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated:DeprecationWarning:xdist.plugin",
 
     # -- fixed, waiting for release / update
+    # https://github.com/ludeeus/aiogithubapi/pull/208 - >=23.9.0
+    "ignore:datetime.*utcnow\\(\\) is deprecated and scheduled for removal:DeprecationWarning:aiogithubapi.namespaces.events",
+    # https://github.com/bachya/aiopurpleair/pull/200 - >2023.08.0
+    "ignore:datetime.*utcfromtimestamp\\(\\) is deprecated and scheduled for removal:DeprecationWarning:aiopurpleair.helpers.validators",
+    # https://github.com/scrapinghub/dateparser/pull/1179 - >1.1.8
+    "ignore:datetime.*utcnow\\(\\) is deprecated and scheduled for removal:DeprecationWarning:dateparser.timezone_parser",
+    # https://github.com/zopefoundation/DateTime/pull/55 - >5.2
+    "ignore:datetime.*utcfromtimestamp\\(\\) is deprecated and scheduled for removal:DeprecationWarning:DateTime.pytz_support",
     # https://github.com/kurtmckee/feedparser/issues/330 - >6.0.10
     "ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning:feedparser.encodings",
     # https://github.com/jaraco/jaraco.abode/commit/9e3e789efc96cddcaa15f920686bbeb79a7469e0 - update jaraco.abode to >=5.1.0
     "ignore:`jaraco.functools.call_aside` is deprecated, use `jaraco.functools.invoke` instead:DeprecationWarning:jaraco.abode.helpers.timeline",
     # https://github.com/nextcord/nextcord/pull/1095 - >2.6.1
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning:nextcord.health_check",
+    # https://github.com/bachya/pytile/pull/280 - >2023.08.0
+    "ignore:datetime.*utcfromtimestamp\\(\\) is deprecated and scheduled for removal:DeprecationWarning:pytile.tile",
+    # https://github.com/rytilahti/python-miio/pull/1809 - >0.5.12
+    "ignore:datetime.*utcnow\\(\\) is deprecated and scheduled for removal:DeprecationWarning:miio.protocol",
+    "ignore:datetime.*utcnow\\(\\) is deprecated and scheduled for removal:DeprecationWarning:miio.miioprotocol",
+    # https://github.com/hunterjm/python-onvif-zeep-async/pull/51 - >3.1.12
+    "ignore:datetime.*utcnow\\(\\) is deprecated and scheduled for removal:DeprecationWarning:onvif.client",
+    # Fixed upstream in python-telegram-bot - >=20.0
+    "ignore:python-telegram-bot is using upstream urllib3:UserWarning:telegram.utils.request",
+    # https://github.com/ludeeus/pytraccar/pull/15 - >1.0.0
+    "ignore:datetime.*utcnow\\(\\) is deprecated and scheduled for removal:DeprecationWarning:pytraccar.client",
+    # https://github.com/zopefoundation/RestrictedPython/pull/259 - >=7.0a1.dev0
+    "ignore:ast\\.(Str|Num) is deprecated and will be removed in Python 3.14:DeprecationWarning:RestrictedPython.transformer",
     # https://github.com/grahamwetzler/smart-meter-texas/pull/143 - >0.5.3
     "ignore:ssl.OP_NO_SSL\\*/ssl.OP_NO_TLS\\* options are deprecated:DeprecationWarning:smart_meter_texas",
+    # https://github.com/Bluetooth-Devices/xiaomi-ble/pull/59 - >0.21.1
+    "ignore:datetime.*utcfromtimestamp\\(\\) is deprecated and scheduled for removal:DeprecationWarning:xiaomi_ble.parser",
 
     # -- not helpful
     # pyatmo.__init__ imports deprecated moduls from itself - v7.5.0
@@ -498,10 +530,13 @@ filterwarnings = [
     "ignore:with timeout\\(\\) is deprecated:DeprecationWarning:aiomodernforms.modernforms",
     # https://pypi.org/project/directv/ - v0.4.0 - 2020-09-12
     "ignore:with timeout\\(\\) is deprecated:DeprecationWarning:directv.directv",
+    "ignore:datetime.*utcnow\\(\\) is deprecated and scheduled for removal:DeprecationWarning:directv.models",
     # https://pypi.org/project/emulated-roku/ - v0.2.1 - 2020-01-23 (archived)
     "ignore:loop argument is deprecated:DeprecationWarning:emulated_roku",
     # https://pypi.org/project/foobot_async/ - v1.0.0 - 2020-11-24
     "ignore:with timeout\\(\\) is deprecated:DeprecationWarning:foobot_async",
+    # https://pypi.org/project/influxdb/ - v5.3.1 - 2020-11-11 (archived)
+    "ignore:datetime.*utcfromtimestamp\\(\\) is deprecated and scheduled for removal:DeprecationWarning:influxdb.line_protocol",
     # https://pypi.org/project/lark-parser/ - v0.12.0 - 2021-08-30 -> moved to `lark`
     # https://pypi.org/project/commentjson/ - v0.9.0 - 2020-10-05
     # https://github.com/vaidik/commentjson/issues/51
@@ -510,17 +545,46 @@ filterwarnings = [
     "ignore:module '(sre_parse|sre_constants)' is deprecate:DeprecationWarning:lark.utils",
     # https://pypi.org/project/lomond/ - v0.3.3 - 2018-09-21
     "ignore:ssl.PROTOCOL_TLS is deprecated:DeprecationWarning:lomond.session",
+    # https://pypi.org/project/oauth2client/ - v4.1.3 - 2018-09-07 (archived)
+    "ignore:datetime.*utcnow\\(\\) is deprecated and scheduled for removal:DeprecationWarning:oauth2client.client",
     # https://pypi.org/project/passlib/ - v1.7.4 - 2020-10-08
     "ignore:'crypt' is deprecated and slated for removal in Python 3.13:DeprecationWarning:passlib.utils",
+    # https://pypi.org/project/PyMetEireann/ - v2021.8.0 - 2021-08-16
+    "ignore:datetime.*utcnow\\(\\) is deprecated and scheduled for removal:DeprecationWarning:meteireann",
     # https://pypi.org/project/pyqwikswitch/ - v0.94 - 2019-08-19
     "ignore:client.loop property is deprecated:DeprecationWarning:pyqwikswitch.async_",
     "ignore:with timeout\\(\\) is deprecated:DeprecationWarning:pyqwikswitch.async_",
+    # https://pypi.org/project/Rx/ - v3.2.0 - 2021-04-25
+    "ignore:datetime.*utcfromtimestamp\\(\\) is deprecated and scheduled for removal:DeprecationWarning:rx.internal.constants",
     # https://pypi.org/project/rxv/ - v0.7.0 - 2021-10-10
     "ignore:defusedxml.cElementTree is deprecated, import from defusedxml.ElementTree instead:DeprecationWarning:rxv.ssdp",
     # https://pypi.org/project/vilfo-api-client/ - v0.4.1 - 2021-11-06
     "ignore:Function 'semver.compare' is deprecated. Deprecated since version 3.0.0:PendingDeprecationWarning:.*vilfo.client",
     # https://pypi.org/project/webrtcvad/ - v2.0.10 - 2017-01-08
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning:webrtcvad",
+
+    # -- existing issues
+    "ignore:'audioop' is deprecated and slated for removal in Python 3.13:DeprecationWarning:homeassistant.components.assist_pipeline.websocket_api",
+    "ignore:This method will be removed future version, pass the callback to the BleakClient constructor instead:FutureWarning:homeassistant.components.bluetooth.wrappers",
+    "ignore:The asyncore module is deprecated and will be removed in Python 3.12:DeprecationWarning:pysnmp.carrier.asyncore.base",
+
+    # -- ignore
+    # https://github.com/protocolbuffers/protobuf - v4.24.3
+    "ignore:datetime.*utcfromtimestamp\\(\\) is deprecated and scheduled for removal:DeprecationWarning:google.protobuf.internal.well_known_types",
+    "ignore:Type google._upb._message.(Message|Scalar)MapContainer uses PyType_Spec with a metaclass that has custom tp_new. .* Python 3.14:DeprecationWarning",
+    # https://github.com/googleapis/google-auth-library-python/blob/v2.23.2/google/auth/_helpers.py#L95 - v2.23.2
+    "ignore:datetime.*utcnow\\(\\) is deprecated:DeprecationWarning:google.auth._helpers",
+    # https://github.com/googleapis/proto-plus-python/blob/v1.22.3/proto/datetime_helpers.py#L24 - v1.22.3
+    "ignore:datetime.*utcfromtimestamp\\(\\) is deprecated:DeprecationWarning:proto.datetime_helpers",
+    # https://github.com/MatsNl/pyatag/issues/11 -> no recent activity - v0.3.6.2
+    "ignore:datetime.*utcnow\\(\\) is deprecated and scheduled for removal:DeprecationWarning:pyatag.gateway",
+    # https://github.com/Python-MyQ/Python-MyQ -> fork - v3.1.11
+    "ignore:datetime.*utcnow\\(\\) is deprecated and scheduled for removal:DeprecationWarning:pymyq.(api|account)",
+    # Aiohttp 3.9.0 UserWarnings handled in another branch
+    "ignore:It is recommended to use web.AppKey instances for keys:UserWarning",
+
+    # -- enable warnings
+    "error::sqlalchemy.exc.SAWarning",
 ]
 
 [tool.ruff]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -565,9 +565,6 @@ boto3==1.28.17
 # homeassistant.components.broadlink
 broadlink==0.18.3
 
-# homeassistant.components.brother
-brother==2.3.0
-
 # homeassistant.components.brottsplatskartan
 brottsplatskartan==0.0.1
 
@@ -2036,9 +2033,6 @@ pysmartthings==0.7.8
 
 # homeassistant.components.edl21
 pysml==0.0.12
-
-# homeassistant.components.snmp
-pysnmplib==5.0.21
 
 # homeassistant.components.snooz
 pysnooz==0.8.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2671,9 +2671,6 @@ vsure==2.6.6
 # homeassistant.components.vasttrafik
 vtjp==0.1.14
 
-# homeassistant.components.vulcan
-vulcan-api==2.3.0
-
 # homeassistant.components.vultr
 vultr==0.1.2
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -641,9 +641,6 @@ crownstone-uart==2.1.0
 # homeassistant.components.datadog
 datadog==0.15.0
 
-# homeassistant.components.metoffice
-datapoint==0.9.8
-
 # homeassistant.components.bluetooth
 dbus-fast==2.11.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2693,9 +2693,6 @@ watchdog==2.3.1
 # homeassistant.components.waterfurnace
 waterfurnace==1.1.0
 
-# homeassistant.components.cisco_webex_teams
-webexteamssdk==1.1.1
-
 # homeassistant.components.assist_pipeline
 webrtc-noise-gain==1.2.3
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -929,9 +929,6 @@ gspread==5.5.0
 # homeassistant.components.gstreamer
 gstreamer-player==1.1.2
 
-# homeassistant.components.profiler
-guppy3==3.1.3
-
 # homeassistant.components.iaqualink
 h2==4.1.0
 
@@ -1318,9 +1315,6 @@ oasatelematics==0.3
 
 # homeassistant.components.google
 oauth2client==4.1.3
-
-# homeassistant.components.profiler
-objgraph==3.5.0
 
 # homeassistant.components.garages_amsterdam
 odp-amsterdam==5.3.1
@@ -1938,9 +1932,6 @@ pyplaato==0.0.18
 
 # homeassistant.components.point
 pypoint==2.3.2
-
-# homeassistant.components.profiler
-pyprof2calltree==1.4.5
 
 # homeassistant.components.prosegur
 pyprosegur==0.0.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -122,7 +122,7 @@ PyXiaomiGateway==0.14.3
 RachioPy==1.0.3
 
 # homeassistant.components.python_script
-RestrictedPython==6.2
+RestrictedPython==7.0a1.dev0
 
 # homeassistant.components.remember_the_milk
 RtmAPI==0.7.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -261,9 +261,6 @@ aiohue==4.7.0
 # homeassistant.components.imap
 aioimaplib==1.0.1
 
-# homeassistant.components.apache_kafka
-aiokafka==0.7.2
-
 # homeassistant.components.kef
 aiokef==0.2.16
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -730,9 +730,6 @@ growattServer==1.3.0
 # homeassistant.components.google_sheets
 gspread==5.5.0
 
-# homeassistant.components.profiler
-guppy3==3.1.3
-
 # homeassistant.components.iaqualink
 h2==4.1.0
 
@@ -1020,9 +1017,6 @@ numpy==1.26.0
 
 # homeassistant.components.google
 oauth2client==4.1.3
-
-# homeassistant.components.profiler
-objgraph==3.5.0
 
 # homeassistant.components.garages_amsterdam
 odp-amsterdam==5.3.1
@@ -1460,9 +1454,6 @@ pyplaato==0.0.18
 
 # homeassistant.components.point
 pypoint==2.3.2
-
-# homeassistant.components.profiler
-pyprof2calltree==1.4.5
 
 # homeassistant.components.prosegur
 pyprosegur==0.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -109,7 +109,7 @@ PyXiaomiGateway==0.14.3
 RachioPy==1.0.3
 
 # homeassistant.components.python_script
-RestrictedPython==6.2
+RestrictedPython==7.0a1.dev0
 
 # homeassistant.components.remember_the_milk
 RtmAPI==0.7.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1983,9 +1983,6 @@ volvooncall==0.10.3
 # homeassistant.components.verisure
 vsure==2.6.6
 
-# homeassistant.components.vulcan
-vulcan-api==2.3.0
-
 # homeassistant.components.vultr
 vultr==0.1.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -524,9 +524,6 @@ crownstone-uart==2.1.0
 # homeassistant.components.datadog
 datadog==0.15.0
 
-# homeassistant.components.metoffice
-datapoint==0.9.8
-
 # homeassistant.components.bluetooth
 dbus-fast==2.11.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -239,9 +239,6 @@ aiohue==4.7.0
 # homeassistant.components.imap
 aioimaplib==1.0.1
 
-# homeassistant.components.apache_kafka
-aiokafka==0.7.2
-
 # homeassistant.components.lifx
 aiolifx-effects==0.3.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -475,9 +475,6 @@ boschshcpy==0.2.57
 # homeassistant.components.broadlink
 broadlink==0.18.3
 
-# homeassistant.components.brother
-brother==2.3.0
-
 # homeassistant.components.brottsplatskartan
 brottsplatskartan==0.0.1
 
@@ -1537,9 +1534,6 @@ pysmartthings==0.7.8
 
 # homeassistant.components.edl21
 pysml==0.0.12
-
-# homeassistant.components.snmp
-pysnmplib==5.0.21
 
 # homeassistant.components.snooz
 pysnooz==0.8.6

--- a/tests/components/apache_kafka/conftest.py
+++ b/tests/components/apache_kafka/conftest.py
@@ -1,0 +1,3 @@
+"""Skip test collection."""
+
+collect_ignore_glob = ["test_*.py"]

--- a/tests/components/brother/__init__.py
+++ b/tests/components/brother/__init__.py
@@ -1,8 +1,9 @@
 """Tests for Brother Printer integration."""
+# ruff: noqa: F821
 import json
 from unittest.mock import patch
 
-from homeassistant.components.brother.const import DOMAIN
+# from homeassistant.components.brother.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_TYPE
 from homeassistant.core import HomeAssistant
 

--- a/tests/components/brother/conftest.py
+++ b/tests/components/brother/conftest.py
@@ -4,6 +4,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+collect_ignore_glob = ["test_*.py"]
+
 
 @pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock, None, None]:

--- a/tests/components/metoffice/conftest.py
+++ b/tests/components/metoffice/conftest.py
@@ -1,8 +1,11 @@
 """Fixtures for Met Office weather integration tests."""
+# ruff: noqa: F821
 from unittest.mock import patch
 
-from datapoint.exceptions import APIException
+# from datapoint.exceptions import APIException
 import pytest
+
+collect_ignore_glob = ["test_*.py"]
 
 
 @pytest.fixture

--- a/tests/components/profiler/conftest.py
+++ b/tests/components/profiler/conftest.py
@@ -1,0 +1,3 @@
+"""Skip test collection."""
+
+collect_ignore_glob = ["test_*.py"]

--- a/tests/components/snmp/conftest.py
+++ b/tests/components/snmp/conftest.py
@@ -1,0 +1,3 @@
+"""Skip test collection."""
+
+collect_ignore_glob = ["test_*.py"]

--- a/tests/components/vulcan/conftest.py
+++ b/tests/components/vulcan/conftest.py
@@ -1,0 +1,3 @@
+"""Skip test collection."""
+
+collect_ignore_glob = ["test_*.py"]


### PR DESCRIPTION
### Done
- [x] Update `PyYAML` to `6.0.1`
https://github.com/yaml/pyyaml/pull/702
- [x] `orjson==3.9.2` -> `3.9.7`
reads `tp_dict` directly -> unsafe. Use `PyType_GetDict` instead.
https://github.com/ijl/orjson/pull/408
https://github.com/ijl/orjson/releases/tag/3.9.3
https://github.com/home-assistant/core/pull/99374
https://github.com/ijl/orjson/issues/415
https://github.com/home-assistant/core/pull/99938
- [x] `DTLSSocket==0.1.5` -> pin cython `<3.0`
https://github.com/kabel42/DTLSSocket/pull/9
- [x] `construct==2.10.56` uses removed module `imp` -> Update to `2.10.57`
https://github.com/construct/construct/pull/837
- [x] `zigpy` -> `0.57.2`
https://github.com/zigpy/zigpy/pull/1232
https://github.com/zigpy/zigpy/pull/1236
https://github.com/zigpy/zigpy/issues/1253
https://github.com/zigpy/zigpy/pull/1254
- [x] `zigpy-znp` -> `0.11.4`
https://github.com/zigpy/zigpy-znp/pull/219
- [x] `ha-av==10.1.0` -> `10.1.1`
https://github.com/PyAV-Org/PyAV/issues/1140
https://github.com/uvjustin/PyAV/pull/1
- [x] `aiopvpc==4.1.0` -> `4.2.2`
https://github.com/azogue/aiopvpc/pull/59
https://github.com/azogue/aiopvpc/releases/tag/v4.2.2
- [x] `pydiscovergy==2.0.1` -> `dataclasses-json==0.15.13`
https://github.com/jpbede/pydiscovergy/issues/78
https://github.com/lidatong/dataclasses-json/pull/449
- [x] `zeroconf==0.71` -> test failures when build from source
https://github.com/python-zeroconf/python-zeroconf/issues/1197
- [x] `plugwise` -> `0.31.7`
https://github.com/plugwise/python-plugwise/pull/355
- [x] `numpy==1.23.2` -> `1.26.0`
https://github.com/numpy/numpy/issues/23808
- [x] `pandas-2.1.0` -> `2.1.1`
https://github.com/pandas-dev/pandas/issues/53665
https://github.com/pandas-dev/pandas/issues/54447
https://github.com/pandas-dev/pandas/pull/55010
https://github.com/pandas-dev/pandas/pull/55175
- [x] `greenlet` -> `3.0.0`
https://github.com/python-greenlet/greenlet/issues/323
- [x] `grpcio==1.59.0`
https://github.com/grpc/grpc/issues/33063
https://github.com/grpc/grpc/issues/33918
- [x] `ephem==4.1.2` -> `4.1.5` uses removed C-function `PyUnicode_GET_SIZE`
https://github.com/brandon-rhodes/pyephem/blob/4.1.2/extensions/_libastro.c#L183
https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_GET_SIZE
https://github.com/brandon-rhodes/pyephem/pull/259
- [x] `pydrawise==2023.7.0`
  - [x] -> `gql[aiohttp]` depends on `aiohttp<3.9`
https://github.com/dknowles2/pydrawise
https://github.com/graphql-python/gql/pull/425
https://github.com/graphql-python/gql/issues/427
https://github.com/dknowles2/pydrawise/pull/84
https://github.com/home-assistant/core/pull/101548
  - [x] -> `apischema==0.18.0` -> `0.18.1` fails to build on 3.12
https://github.com/wyfo/apischema/pull/590
- [x] `aiohttp==3.8.5` -> `3.9.0`?
-> Workaround: Build without extension modules
https://github.com/aio-libs/aiohttp/issues/7229
https://github.com/MagicStack/uvloop/issues/547
https://github.com/aio-libs/aiohttp/pull/7400
https://github.com/nodejs/llhttp/issues/249
https://github.com/aio-libs/aiohttp/issues/7639
https://github.com/home-assistant/core/pull/101627
- [x] `guppy3==3.1.3` -> `3.1.4`
https://github.com/zhuyifei1999/guppy3
https://github.com/home-assistant/core/pull/102400

### Update dependencies
- [ ] `RestrictedPython` -> `7.0`
https://github.com/zopefoundation/RestrictedPython/issues/246

### Todo's

#### Python limit

#### Versionieer -> `>=0.19.0`
- [ ] `datapoint==0.9.8` Update `python-versionieer`
https://github.com/EJEP/datapoint-python/issues/183
-> unmaintained
- [ ] `webexteamssdk==1.1.1` Update `python-versionieer` -> `1.6.1`?
https://github.com/WebexCommunity/WebexPythonSDK/issues/189

#### Cython -> `<3.0`

#### Setuptools compatibility

#### C-API changes

#### Other wheel build failure

#### Import issues
- [ ] `brother==2.3.0` -> `pysnmplib`
- [ ] `pysnmplib==5.0.21` still uses `asyncore`
https://github.com/pysnmp/pysnmp
- [ ] `vulcan-api==2.3.0` -> `related~=0.7.3` -> `future` depends on `imp`
https://github.com/kapi2289/vulcan-api
https://github.com/genomoncology/related
https://github.com/PythonCharmers/python-future
https://github.com/PythonCharmers/python-future/issues/246
https://github.com/PythonCharmers/python-future/issues/488
https://github.com/PythonCharmers/python-future/pull/574
- [ ] `aiokafka==0.7.2` -> `kafka-python>=2.0.0`
https://github.com/dpkp/kafka-python/pull/2376
https://github.com/dpkp/kafka-python/issues/1927

#### aiohttp 3.9.0


#### Fix tests
- [x] `hassio` -> Change in `asyncio.Server.wait_closed()`
https://github.com/python/cpython/issues/104344
https://github.com/python/cpython/pull/98582
- [x] `script` -> Change in `asyncio.wait_for`
https://github.com/python/cpython/pull/98518 
- [x] https://github.com/home-assistant/core/pull/101006
- [x] https://github.com/home-assistant/core/pull/101252